### PR TITLE
GDQuest Docker Plugin

### DIFF
--- a/gdquest-godot-theme/addons/color_palette/ColorPalettePlugin.gd
+++ b/gdquest-godot-theme/addons/color_palette/ColorPalettePlugin.gd
@@ -14,15 +14,10 @@ func _enter_tree() -> void:
 	_interface = INTERFACE_SCENE.instance() as ColorPalette
 	_interface.connect("color_picked", self, "set_canvas_items_modulate")
 	_interface.connect("palette_selected", self, "update_palette")
-	
-	add_control_to_dock(EditorPlugin.DOCK_SLOT_LEFT_BR, _interface)
 
 	load_palettes(PATH)
 	update_palette(palettes.keys()[0])
 
-
-func _exit_tree() -> void:
-	remove_control_from_docks(_interface)
 
 func get_interface() -> ColorPalette:
 	return _interface as ColorPalette

--- a/gdquest-godot-theme/addons/gdquest_docker/GDQuestDocker.gd
+++ b/gdquest-godot-theme/addons/gdquest_docker/GDQuestDocker.gd
@@ -1,0 +1,130 @@
+tool
+extends EditorPlugin
+"""
+A container for plugins' widgets that provides an easy access to enable/disable valid plugins
+
+Notes
+---
+A valid plugin must have the EditorPlugin.get_plugin_name() -> String virtual method implemented
+and also a custom get_interface() -> Control method implemented.
+"""
+
+onready var _interface: Docker
+onready var _editor: EditorInterface = get_editor_interface()
+
+const INTERFACE_SCENE: PackedScene = preload("res://addons/gdquest_docker/interface/Docker.tscn")
+const PLUGIN_CHECKBOX: PackedScene = preload("res://addons/gdquest_docker/interface/plugin_checkbox/PluginCheckBox.tscn")
+const ADDONS_FOLDER_PATH: String = "res://addons"
+
+
+func _enter_tree() -> void:
+	_interface = INTERFACE_SCENE.instance()
+	add_control_to_dock(EditorPlugin.DOCK_SLOT_LEFT_UL, _interface)
+
+
+func _exit_tree() -> void:
+	var plugins: = _interface.get_plugins_list()
+
+	for checkbox in plugins.get_children():
+		if not checkbox.pressed:
+			continue
+		_editor.set_plugin_enabled(checkbox.plugin_name, false)
+
+	remove_control_from_docks(_interface)
+
+func _ready():
+	load_plugins()
+
+
+func load_plugins() -> void:
+	var addons_folder: Directory = Directory.new()
+	if not addons_folder.dir_exists(ADDONS_FOLDER_PATH):
+		return
+
+	addons_folder.open(ADDONS_FOLDER_PATH)
+	addons_folder.list_dir_begin(true)
+	var addon: String = addons_folder.get_next()
+
+	while not addon == "":
+		add_plugin_to_list(addon)
+		addon = addons_folder.get_next()
+
+
+func add_plugin_to_list(plugin_name: String) -> void:
+	if plugin_name == get_plugin_name():
+		return
+
+	var plugin_checkbox: PluginCheckBox = PLUGIN_CHECKBOX.instance()
+	plugin_checkbox.plugin_name = plugin_name
+	plugin_checkbox.connect("toggled", self, "set_plugin_enabled", [plugin_name])
+	_interface.add_plugin_checkbox(plugin_checkbox)
+
+
+func remove_plugin_from_list(plugin_name: String) -> void:
+	var plugins_list: = _interface.get_plugins_list()
+
+	for c in plugins_list:
+		if c.plugin_name == plugin_name:
+			_interface.remove_plugin_checkbox(c)
+			break
+
+
+func add_widget(widget : Control) -> void:
+	var container: = _interface.get_widget_container()
+	container.add_child(widget)
+
+
+func remove_widget(widget : Control) -> void:
+	var container: = _interface.get_widget_container()
+	container.remove_child(widget)
+
+
+func set_plugin_enabled(enabled: bool, plugin_name: String) -> void:
+	if not _editor.is_plugin_enabled(plugin_name):
+		if enabled:
+			_editor.set_plugin_enabled(plugin_name, true)
+
+	var plugin: = get_plugin(plugin_name)
+
+	if plugin.has_method("get_interface"):
+		if enabled:
+			add_widget(plugin.get_interface())
+		else:
+			remove_widget(plugin.get_interface())
+			_editor.set_plugin_enabled(plugin_name, enabled)
+
+
+func get_plugin_name() -> String:
+	return "gdquest_docker"
+
+
+"""
+Currently is not possible to get the plugin's node directly in the Editor,
+i.e. to simply EditorInterface.get_plugin(String plugin_name) -> EditorPlugin
+So these two methods are used as a workaround to find an EditorPlugin's Node
+"""
+func get_plugins_list() -> Array:
+	var plugins: Array = []
+
+	"""
+	Since is uncertain what is the actual Node's name in the parent,
+	we presume that an EditorPlugin is valid when it implements the
+	get_plugin_name virtual method, otherwise we ignore it
+	"""
+	for n in get_parent().get_children():
+		if not n.has_method("get_plugin_name"):
+			continue
+		if n.get_plugin_name() == "":
+			continue
+		plugins.append(n)
+
+	return plugins
+
+
+func get_plugin(plugin_name) -> EditorPlugin:
+	var plugin: = EditorPlugin.new()
+	for p in get_plugins_list():
+		if p.get_plugin_name() == plugin_name:
+			plugin = p
+			break
+	return plugin

--- a/gdquest-godot-theme/addons/gdquest_docker/interface/Docker.gd
+++ b/gdquest-godot-theme/addons/gdquest_docker/interface/Docker.gd
@@ -1,0 +1,26 @@
+tool
+extends MarginContainer
+class_name Docker
+
+onready var _widget_container: VBoxContainer = $Column/WidgetContainer/List
+onready var _plugins_list: VBoxContainer = $Column/PluginsList
+
+func get_widget_container() -> VBoxContainer:
+	return _widget_container as VBoxContainer
+
+
+func get_plugins_list() -> VBoxContainer:
+	return _plugins_list as VBoxContainer
+
+
+func add_plugin_checkbox(checkbox: PluginCheckBox) -> void:
+	_plugins_list.add_child(checkbox)
+
+
+func remove_plugin_checkox(checkbox: PluginCheckBox) -> void:
+	_plugins_list.remove_child(checkbox)
+
+
+func _on_Plugins_toggled(button_pressed: bool):
+	_plugins_list.visible = button_pressed
+

--- a/gdquest-godot-theme/addons/gdquest_docker/interface/Docker.tscn
+++ b/gdquest-godot-theme/addons/gdquest_docker/interface/Docker.tscn
@@ -1,0 +1,48 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://addons/gdquest_docker/interface/Docker.gd" type="Script" id=1]
+
+[node name="GDQuestDocker" type="MarginContainer"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+custom_constants/margin_right = 8
+custom_constants/margin_top = 8
+custom_constants/margin_left = 8
+custom_constants/margin_bottom = 8
+script = ExtResource( 1 )
+
+[node name="Column" type="VBoxContainer" parent="."]
+margin_left = 8.0
+margin_top = 8.0
+margin_right = 1912.0
+margin_bottom = 1072.0
+
+[node name="Plugins" type="Button" parent="Column"]
+margin_right = 1904.0
+margin_bottom = 20.0
+toggle_mode = true
+text = "Plugins"
+flat = true
+
+[node name="PluginsList" type="VBoxContainer" parent="Column"]
+visible = false
+margin_top = 24.0
+margin_right = 1904.0
+margin_bottom = 24.0
+
+[node name="WidgetContainer" type="ScrollContainer" parent="Column"]
+margin_top = 24.0
+margin_right = 1904.0
+margin_bottom = 1064.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="List" type="VBoxContainer" parent="Column/WidgetContainer"]
+margin_right = 1904.0
+margin_bottom = 1040.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[connection signal="toggled" from="Column/Plugins" to="." method="_on_Plugins_toggled"]

--- a/gdquest-godot-theme/addons/gdquest_docker/interface/plugin_checkbox/PluginCheckBox.gd
+++ b/gdquest-godot-theme/addons/gdquest_docker/interface/plugin_checkbox/PluginCheckBox.gd
@@ -1,0 +1,9 @@
+tool
+extends CheckBox
+class_name PluginCheckBox
+
+var plugin_name : String = "" setget set_plugin_name
+
+func set_plugin_name(new_name : String):
+	plugin_name = new_name
+	text = plugin_name.capitalize()

--- a/gdquest-godot-theme/addons/gdquest_docker/interface/plugin_checkbox/PluginCheckBox.tscn
+++ b/gdquest-godot-theme/addons/gdquest_docker/interface/plugin_checkbox/PluginCheckBox.tscn
@@ -1,0 +1,9 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://addons/gdquest_docker/interface/plugin_checkbox/PluginCheckBox.gd" type="Script" id=1]
+
+[node name="PluginCheckBox" type="CheckBox"]
+anchor_bottom = 1.0
+margin_right = 24.0
+script = ExtResource( 1 )
+

--- a/gdquest-godot-theme/addons/gdquest_docker/plugin.cfg
+++ b/gdquest-godot-theme/addons/gdquest_docker/plugin.cfg
@@ -1,0 +1,7 @@
+[plugin]
+
+name="GDQuest Docker"
+description="A custom docker that contains a set of common use plugins."
+author="Henrique Campos"
+version="0.1.0"
+script="GDQuestDocker.gd"


### PR DESCRIPTION
The GDQuest Docker is a Plugin that behaves as a container for other plugins' widgets. You can add and remove widgets. It also provides an easy to access way to enable and disable plugins.

With that, I removed the lines from `ColorPalette` responsible for adding its interface as a docker and now we can use the `GDQuest Docker` to add its interface as a widget inside of it.

This closes #21 

![ezgif com-video-to-gif-min](https://user-images.githubusercontent.com/10171059/52853738-a0908700-3103-11e9-8ebb-bfb80bab8bfa.gif)
