### PR TITLE
GDDocker - The ultimate RichTextLabel Editor 

### DIFF
--- a/gdquest-godot-theme/addons/bounding_box_resize/BoundingBoxResize.gd
+++ b/gdquest-godot-theme/addons/bounding_box_resize/BoundingBoxResize.gd
@@ -4,23 +4,26 @@ extends EditorPlugin
 Updates RichTextLabel and TextEdit minimum rect size to fit their content
 """
 
-onready var _editor: = get_editor_interface()
-onready var _selection: = _editor.get_selection()
-onready var _interface: Button
-
 const INTERFACE_SCENE: PackedScene = preload("res://addons/bounding_box_resize/interface/RefreshButton.tscn")
+
+var _editor: = get_editor_interface()
+var _selection: = _editor.get_selection()
+var _interface: Button = Button.new()
 
 func _ready() -> void:
 	_interface = INTERFACE_SCENE.instance()
 	_interface.visible = false
 	_interface.connect("pressed", self, "_on_Button_pressed")
-	add_control_to_container(CONTAINER_CANVAS_EDITOR_MENU, _interface)
+	
+	if not _editor.is_plugin_enabled("gdquest_docker"):
+		add_control_to_container(CONTAINER_CANVAS_EDITOR_MENU, _interface)
 	
 	_selection.connect("selection_changed", self, "_on_EditorSelection_selection_changed")
 
 
 func _exit_tree():
-	remove_control_from_container(CONTAINER_CANVAS_EDITOR_MENU, _interface)
+	if not _editor.is_plugin_enabled("gdquest_docker"):
+		remove_control_from_container(CONTAINER_CANVAS_EDITOR_MENU, _interface)
 
 
 func _on_EditorSelection_selection_changed() -> void:
@@ -39,6 +42,14 @@ func _on_Button_pressed() -> void:
 	var nodes: = _selection.get_selected_nodes()
 	for n in nodes:
 		fit_rect_vertically(n)
+
+
+func get_plugin_name() -> String:
+	return "bounding_box_resize"
+
+
+func get_interface() -> Control:
+	return _interface
 
 
 func fit_rect_vertically(control: Control) -> void:

--- a/gdquest-godot-theme/addons/bounding_box_resize/plugin.cfg
+++ b/gdquest-godot-theme/addons/bounding_box_resize/plugin.cfg
@@ -3,5 +3,5 @@
 name="Bounding Box Resize"
 description="A plugin that automatically resize RichText and TextEdit's bounding box to fits its content."
 author="Henrique Campos"
-version="0.1.0"
+version="0.1.1"
 script="BoundingBoxResize.gd"

--- a/gdquest-godot-theme/addons/color_palette/ColorPalettePlugin.gd
+++ b/gdquest-godot-theme/addons/color_palette/ColorPalettePlugin.gd
@@ -9,14 +9,23 @@ const PATH: = "res://addons/color_palette/palettes/"
 const INTERFACE_SCENE: PackedScene = preload("res://addons/color_palette/interface/ColorPalette.tscn")
 
 var palettes: Dictionary = {}
+var _editor: = get_editor_interface()
 
 func _enter_tree() -> void:
 	_interface = INTERFACE_SCENE.instance() as ColorPalette
 	_interface.connect("color_picked", self, "set_canvas_items_modulate")
 	_interface.connect("palette_selected", self, "update_palette")
 
+	if not _editor.is_plugin_enabled("gdquest_docker"):
+		add_control_to_dock(DOCK_SLOT_LEFT_BL, _interface)
+	
 	load_palettes(PATH)
 	update_palette(palettes.keys()[0])
+
+
+func _exit_tree():
+	if not _editor.is_plugin_enabled("gdquest_docker"):
+		remove_control_from_docks(_interface)
 
 
 func get_interface() -> ColorPalette:
@@ -25,6 +34,7 @@ func get_interface() -> ColorPalette:
 
 func get_plugin_name() -> String:
 	return "color_palette"
+
 
 func load_palettes(palettes_folder) -> void:
 	var directory: Directory = Directory.new()
@@ -42,6 +52,7 @@ func load_palettes(palettes_folder) -> void:
 			add_palette(palette["id"], palette)
 
 			file_name = directory.get_next()
+
 
 func update_palette(palette_name: String) -> void:
 	_interface.clear()
@@ -70,7 +81,7 @@ func set_canvas_items_modulate(hex_color: String) -> void:
 	undo.create_action("Set Modulate")
 	
 	for n in selection.get_selected_nodes():
-		if not n.has_method("set_modulate"):
+		if not n.has_method("set_modulate") or n is RichTextLabel:
 			continue
 		undo.add_undo_property(n, "modulate", n.modulate)
 		n.modulate = Color(hex_color)

--- a/gdquest-godot-theme/addons/color_palette/interface/ColorPalette.tscn
+++ b/gdquest-godot-theme/addons/color_palette/interface/ColorPalette.tscn
@@ -1,7 +1,6 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=2 format=2]
 
 [ext_resource path="res://addons/color_palette/interface/ColorPalette.gd" type="Script" id=1]
-[ext_resource path="res://addons/color_palette/interface/color_swatch/ColorSwatch.tscn" type="PackedScene" id=2]
 
 [node name="ColorPalette" type="MarginContainer"]
 anchor_right = 1.0
@@ -9,7 +8,6 @@ anchor_bottom = 1.0
 margin_right = -1497.0
 margin_bottom = -598.0
 script = ExtResource( 1 )
-color_swatch = ExtResource( 2 )
 
 [node name="Column" type="VBoxContainer" parent="."]
 margin_right = 423.0

--- a/gdquest-godot-theme/addons/color_palette/plugin.cfg
+++ b/gdquest-godot-theme/addons/color_palette/plugin.cfg
@@ -3,5 +3,5 @@
 name="Color Palette"
 description="A widget that loads palettes from json files. Allows the user to easily assign CanvasItems's modulate."
 author="Henrique Campos"
-version="0.1.0"
+version="0.1.1"
 script="ColorPalettePlugin.gd"

--- a/gdquest-godot-theme/addons/gdquest_docker/interface/Docker.gd
+++ b/gdquest-godot-theme/addons/gdquest_docker/interface/Docker.gd
@@ -3,24 +3,7 @@ extends MarginContainer
 class_name Docker
 
 onready var _widget_container: VBoxContainer = $Column/WidgetContainer/List
-onready var _plugins_list: VBoxContainer = $Column/PluginsList
 
 func get_widget_container() -> VBoxContainer:
 	return _widget_container as VBoxContainer
-
-
-func get_plugins_list() -> VBoxContainer:
-	return _plugins_list as VBoxContainer
-
-
-func add_plugin_checkbox(checkbox: PluginCheckBox) -> void:
-	_plugins_list.add_child(checkbox)
-
-
-func remove_plugin_checkox(checkbox: PluginCheckBox) -> void:
-	_plugins_list.remove_child(checkbox)
-
-
-func _on_Plugins_toggled(button_pressed: bool):
-	_plugins_list.visible = button_pressed
 

--- a/gdquest-godot-theme/addons/gdquest_docker/interface/Docker.tscn
+++ b/gdquest-godot-theme/addons/gdquest_docker/interface/Docker.tscn
@@ -19,21 +19,7 @@ margin_top = 8.0
 margin_right = 1912.0
 margin_bottom = 1072.0
 
-[node name="Plugins" type="Button" parent="Column"]
-margin_right = 1904.0
-margin_bottom = 20.0
-toggle_mode = true
-text = "Plugins"
-flat = true
-
-[node name="PluginsList" type="VBoxContainer" parent="Column"]
-visible = false
-margin_top = 24.0
-margin_right = 1904.0
-margin_bottom = 24.0
-
 [node name="WidgetContainer" type="ScrollContainer" parent="Column"]
-margin_top = 24.0
 margin_right = 1904.0
 margin_bottom = 1064.0
 size_flags_horizontal = 3
@@ -41,8 +27,7 @@ size_flags_vertical = 3
 
 [node name="List" type="VBoxContainer" parent="Column/WidgetContainer"]
 margin_right = 1904.0
-margin_bottom = 1040.0
+margin_bottom = 1064.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
 
-[connection signal="toggled" from="Column/Plugins" to="." method="_on_Plugins_toggled"]

--- a/gdquest-godot-theme/addons/gdquest_docker/interface/plugin_checkbox/PluginCheckBox.gd
+++ b/gdquest-godot-theme/addons/gdquest_docker/interface/plugin_checkbox/PluginCheckBox.gd
@@ -1,9 +1,0 @@
-tool
-extends CheckBox
-class_name PluginCheckBox
-
-var plugin_name : String = "" setget set_plugin_name
-
-func set_plugin_name(new_name : String):
-	plugin_name = new_name
-	text = plugin_name.capitalize()

--- a/gdquest-godot-theme/addons/gdquest_docker/interface/plugin_checkbox/PluginCheckBox.tscn
+++ b/gdquest-godot-theme/addons/gdquest_docker/interface/plugin_checkbox/PluginCheckBox.tscn
@@ -1,9 +1,0 @@
-[gd_scene load_steps=2 format=2]
-
-[ext_resource path="res://addons/gdquest_docker/interface/plugin_checkbox/PluginCheckBox.gd" type="Script" id=1]
-
-[node name="PluginCheckBox" type="CheckBox"]
-anchor_bottom = 1.0
-margin_right = 24.0
-script = ExtResource( 1 )
-

--- a/gdquest-godot-theme/addons/gdquest_docker/plugin.cfg
+++ b/gdquest-godot-theme/addons/gdquest_docker/plugin.cfg
@@ -3,5 +3,5 @@
 name="GDQuest Docker"
 description="A custom docker that contains a set of common use plugins."
 author="Henrique Campos"
-version="0.1.0"
+version="0.2.0"
 script="GDQuestDocker.gd"

--- a/gdquest-godot-theme/addons/rich_text_editor/RichTextEditor.gd
+++ b/gdquest-godot-theme/addons/rich_text_editor/RichTextEditor.gd
@@ -1,0 +1,154 @@
+tool
+extends EditorPlugin
+class_name RichTextPlugin
+
+signal text_edit_popped(new_text_edit)
+
+const BUTTON_SCENE: PackedScene = preload("res://addons/rich_text_editor/interface/Button.tscn")
+const INTERFACE_SCENE: PackedScene = preload("res://addons/rich_text_editor/interface/RichEditorInterface.tscn")
+
+var rich_labels: Array = []
+var text_edit: TextEdit = TextEdit.new()
+
+var _editor: = get_editor_interface()
+var _button: Button = BUTTON_SCENE.instance()
+var _selection: = _editor.get_selection()
+var _interface: RichEditorInterface
+
+func _ready() -> void:
+	_button.hide()
+	_button.connect("pressed", self, "_on_Button_pressed")
+	
+	if not _editor.is_plugin_enabled("gdquest_docker"):
+		add_control_to_container(CONTAINER_CANVAS_EDITOR_MENU, _button)
+	
+	_selection.connect("selection_changed", self, "_on_EditorSelection_selection_changed")
+
+
+func _exit_tree() -> void:
+	if not _editor.is_plugin_enabled("gdquest_docker"):
+		remove_control_from_container(CONTAINER_CANVAS_EDITOR_MENU, _button)
+
+
+func _on_Button_pressed() -> void:
+	initialize_interface()
+
+
+func _on_TextEdit_tree_exited() -> void:
+	_button.disabled = false
+
+
+func _on_TextEdit_text_changed() -> void:
+	var undo: = get_undo_redo()
+	
+	undo.create_action("Set BBCode Text")
+	for rich_text_label in rich_labels:
+		rich_text_label.bbcode_enabled = true
+		undo.add_undo_property(rich_text_label, "bbcode_text", rich_text_label.bbcode_text)
+		undo.add_do_property(rich_text_label, "bbcode_text", text_edit.text)
+		rich_text_label.bbcode_text = text_edit.text
+	
+	undo.commit_action()
+
+
+func _on_ColorButton_popup_closed() -> void:
+	colorize_selection(_interface.color_button.color)
+
+
+func _on_EditorSelection_selection_changed() -> void:
+	var rich_labels_only: = is_rich_text_selection(_selection)
+	if rich_labels_only:
+		rich_labels = _selection.get_selected_nodes()
+	else:
+		rich_labels.clear()
+	
+	_button.visible = rich_labels_only
+
+
+func _on_ColorPalette_color_picked(hex_color: String) -> void:
+	_interface.color_button.color = Color(hex_color)
+	colorize_selection(Color(hex_color))
+
+
+func initialize_interface():
+	_interface = INTERFACE_SCENE.instance()
+	
+	if not _editor.is_plugin_enabled("gdquest_docker"):
+		_editor.get_base_control().add_child(_interface)
+	emit_signal("text_edit_popped", _interface)
+	
+	text_edit = _interface.text_edit
+	
+	if rich_labels.size() < 2:
+		var rich_text: RichTextLabel = _editor.get_selection().get_selected_nodes()[0]
+		text_edit.text = rich_text.text
+		if rich_text.bbcode_enabled and not rich_text.bbcode_text.empty():
+			text_edit.text = rich_text.bbcode_text
+	
+	text_edit.connect("text_changed", self, "_on_TextEdit_text_changed")
+	text_edit.connect("tree_exited", self, "_on_TextEdit_tree_exited")
+	
+	_interface.bold_button.connect("pressed", self, "bold_selection")
+	_interface.italic_button.connect("pressed", self, "italic_selection")
+	_interface.color_button.connect("popup_closed", self, "_on_ColorButton_popup_closed")
+	
+	_button.disabled = true
+
+
+func get_plugin_name() -> String:
+	return "rich_text_editor"
+
+
+func get_interface() -> Control:
+	return _button
+
+
+func colorize_selection(color: Color) -> void:
+	var text: = text_edit.get_selection_text()
+	text = "%s" + text + "%s"
+	text = text%["[color=#" + color.to_html() + "]", "[/color]"]
+	
+	insert_bbcode_text(text)
+
+
+func bold_selection() -> void:
+	var text: = text_edit.get_selection_text()
+	text = "%s" + text + "%s"
+	text = text%["[b]", "[/b]"]
+	
+	insert_bbcode_text(text)
+
+
+func italic_selection() -> void:
+	var text: = text_edit.get_selection_text()
+	text = "%s" + text + "%s"
+	text = text%["[i]", "[/i]"]
+	
+	insert_bbcode_text(text)
+
+
+func insert_bbcode_text(new_text: String) -> void:
+	var undo: = get_undo_redo()
+	
+	undo.create_action("Insert BBCode Text")
+	
+	undo.add_undo_property(text_edit, "text", text_edit.text)
+	text_edit.cut()
+	text_edit.insert_text_at_cursor(new_text)
+	undo.add_do_property(text_edit, "text", text_edit.text)
+	undo.commit_action()
+
+
+static func is_rich_text_selection(selection: EditorSelection) -> bool:
+	var rich_labels_only: bool = true
+	var nodes: Array = selection.get_selected_nodes()
+	
+	rich_labels_only = nodes.size() > 0
+	
+	for node in nodes:
+		if not node is RichTextLabel:
+			rich_labels_only = false
+			break
+	
+	return rich_labels_only
+	

--- a/gdquest-godot-theme/addons/rich_text_editor/interface/Button.tscn
+++ b/gdquest-godot-theme/addons/rich_text_editor/interface/Button.tscn
@@ -1,0 +1,16 @@
+[gd_scene load_steps=3 format=2]
+
+[sub_resource type="InputEventKey" id=1]
+control = true
+command = true
+scancode = 69
+
+[sub_resource type="ShortCut" id=2]
+shortcut = SubResource( 1 )
+
+[node name="Button" type="Button"]
+margin_right = 12.0
+margin_bottom = 20.0
+shortcut = SubResource( 2 )
+text = "Rich Edit"
+

--- a/gdquest-godot-theme/addons/rich_text_editor/interface/RichEditorInterface.gd
+++ b/gdquest-godot-theme/addons/rich_text_editor/interface/RichEditorInterface.gd
@@ -1,0 +1,8 @@
+tool
+extends Control
+class_name RichEditorInterface
+
+onready var bold_button: Button = $VBoxContainer/HBoxContainer/Bold
+onready var italic_button: Button = $VBoxContainer/HBoxContainer/Italic
+onready var text_edit: TextEdit = $VBoxContainer/TextEdit
+onready var color_button: ColorPickerButton = $VBoxContainer/HBoxContainer/Color

--- a/gdquest-godot-theme/addons/rich_text_editor/interface/RichEditorInterface.tscn
+++ b/gdquest-godot-theme/addons/rich_text_editor/interface/RichEditorInterface.tscn
@@ -1,0 +1,89 @@
+[gd_scene load_steps=8 format=2]
+
+[ext_resource path="res://addons/rich_text_editor/interface/RichEditorInterface.gd" type="Script" id=1]
+
+[sub_resource type="InputEventKey" id=1]
+control = true
+command = true
+pressed = true
+scancode = 66
+
+[sub_resource type="ShortCut" id=2]
+shortcut = SubResource( 1 )
+
+[sub_resource type="InputEventKey" id=3]
+control = true
+command = true
+pressed = true
+scancode = 73
+
+[sub_resource type="ShortCut" id=4]
+shortcut = SubResource( 3 )
+
+[sub_resource type="InputEventKey" id=5]
+pressed = true
+scancode = 16777217
+
+[sub_resource type="ShortCut" id=6]
+shortcut = SubResource( 5 )
+
+[node name="RichEditorInterface" type="Panel"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = 622.0
+margin_top = 188.0
+margin_right = -622.0
+margin_bottom = -188.0
+size_flags_horizontal = 3
+size_flags_vertical = 3
+script = ExtResource( 1 )
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
+margin_right = 676.0
+margin_bottom = 30.0
+
+[node name="Bold" type="Button" parent="VBoxContainer/HBoxContainer"]
+margin_right = 30.0
+margin_bottom = 30.0
+rect_min_size = Vector2( 30, 0 )
+shortcut = SubResource( 2 )
+text = "B"
+
+[node name="Italic" type="Button" parent="VBoxContainer/HBoxContainer"]
+margin_left = 34.0
+margin_right = 64.0
+margin_bottom = 30.0
+rect_min_size = Vector2( 30, 0 )
+shortcut = SubResource( 4 )
+text = "I"
+
+[node name="Color" type="ColorPickerButton" parent="VBoxContainer/HBoxContainer"]
+margin_left = 68.0
+margin_right = 102.0
+margin_bottom = 30.0
+rect_min_size = Vector2( 34, 30 )
+
+[node name="Spacing" type="Control" parent="VBoxContainer/HBoxContainer"]
+margin_left = 106.0
+margin_right = 652.0
+margin_bottom = 30.0
+size_flags_horizontal = 3
+
+[node name="Close" type="Button" parent="VBoxContainer/HBoxContainer"]
+margin_left = 656.0
+margin_right = 676.0
+margin_bottom = 30.0
+shortcut = SubResource( 6 )
+text = "X"
+
+[node name="TextEdit" type="TextEdit" parent="VBoxContainer"]
+margin_top = 34.0
+margin_right = 676.0
+margin_bottom = 704.0
+size_flags_vertical = 3
+
+[connection signal="pressed" from="VBoxContainer/HBoxContainer/Close" to="." method="queue_free"]

--- a/gdquest-godot-theme/addons/rich_text_editor/plugin.cfg
+++ b/gdquest-godot-theme/addons/rich_text_editor/plugin.cfg
@@ -1,0 +1,7 @@
+[plugin]
+
+name="RichText Editor"
+description="A text editor with BBCode user interface to edit RichTextLabels."
+author="Henrique Campos"
+version="0.1.0"
+script="RichTextEditor.gd"


### PR DESCRIPTION
The present PR aims to close #30 . Each previously individual plugin was integrated to #26 and their functionalities allow an intuitive and smart way to interact with `RichTextLabel.bbcode_text`. All `RichTextLabel` exclusive features are smartly displayed, and hidden, depending on currently selected nodes.

Demo:

![integration_demo](https://user-images.githubusercontent.com/10171059/53426291-7c675c80-39c5-11e9-8919-ff519038c992.gif)

---
Notes:

- You only need to turn the GDDocker Plugin. When enabled it will automatically enable other **valid** plugins, see GDDocker description for more on `valid plugin`.
- Godot throws errors, due to `class_name` usage, on the first run after this PR, when it adds the necessary lines to `project.godot` file. All further uses are clean.
