### PR TITLE
Fix Bounding Box to keep the most suitable size

### DIFF
--- a/gdquest-godot-theme/addons/bounding_box_resize/BoundingBoxResize.gd
+++ b/gdquest-godot-theme/addons/bounding_box_resize/BoundingBoxResize.gd
@@ -4,11 +4,11 @@ extends EditorPlugin
 Updates RichTextLabel and TextEdit minimum rect size to fit their content
 """
 
-const INTERFACE_SCENE: PackedScene = preload("res://addons/bounding_box_resize/interface/RefreshButton.tscn")
+onready var _editor: = get_editor_interface()
+onready var _selection: = _editor.get_selection()
+onready var _interface: Button
 
-var _editor: = get_editor_interface()
-var _selection: = _editor.get_selection()
-var _interface: Button = Button.new()
+const INTERFACE_SCENE: PackedScene = preload("res://addons/bounding_box_resize/interface/RefreshButton.tscn")
 
 func _ready() -> void:
 	_interface = INTERFACE_SCENE.instance()
@@ -17,7 +17,7 @@ func _ready() -> void:
 	
 	if not _editor.is_plugin_enabled("gdquest_docker"):
 		add_control_to_container(CONTAINER_CANVAS_EDITOR_MENU, _interface)
-	
+
 	_selection.connect("selection_changed", self, "_on_EditorSelection_selection_changed")
 
 
@@ -30,8 +30,8 @@ func _on_EditorSelection_selection_changed() -> void:
 	var show_interface: bool = true
 	show_interface = _selection.get_selected_nodes().size() > 0
 
-	for n in _selection.get_selected_nodes():
-		if n is RichTextLabel or n is TextEdit:
+	for node in _selection.get_selected_nodes():
+		if node is RichTextLabel or node is TextEdit:
 			continue
 		show_interface = false
 		break
@@ -53,47 +53,68 @@ func get_interface() -> Control:
 
 
 func fit_rect_vertically(control: Control) -> void:
-	
+	var content_size: = get_content_size(control)
+	if content_size.y < control.rect_size.y:
+		return
+
 	var undo: = get_undo_redo()
 	undo.create_action("Resize Rect Vertically")
 
 	undo.add_undo_property(control, "rect_min_size", control.rect_min_size)
-	control.rect_min_size.y = get_content_size(control).y
+	undo.add_undo_property(control, "rect_size", control.rect_size)
+	control.rect_min_size.y = content_size.y
 	undo.add_do_property(control, "rect_min_size", control.rect_min_size)
-	
+	undo.add_do_property(control, "rect_size", control.rect_size)
+
 	undo.commit_action()
 
 
 """
 Note that this is generalized because Control is the unique common
 ancestor between RichTextLabel and TextEdit, so to prevent any other
-node to go through this function we must have an assertion on their 
+node to go through this function we must have an assertion on their
 text property
 """
 func get_content_size(control: Control) -> Vector2:
-	assert(control.has_method("get_text"))
-	
+	if not control.has_method("get_text"):
+		return control.rect_size
+
+	var font: = get_control_font(control)
+	var text: String = control.text
+
+	var size: Vector2 = get_size_with_lines(text, font)
+	var padding: Vector2 = get_padding(control)
+	size += padding
+
+	return size
+
+
+func get_control_font(control: Control) -> Font:
 	var font: Font
 	var custom_font: String = "font"
-	
 	if control is RichTextLabel:
 		custom_font = "normal_font"
-	
 	font = control.get_font(custom_font)
-	
-	return get_size_with_lines(font, control.text) + get_padding(control)
+	return font
 
 
-func get_size_with_lines(font: Font, string: String) -> Vector2:
+func get_size_with_lines(text: String, font: Font) -> Vector2:
 	var size: = Vector2(0, 0)
-	var lines: PoolStringArray = string.split("\n")
-	
-	for line in lines:
-		var line_size: = font.get_string_size(line)
-		size.x = max(size.x, line_size.x)
-		size.y += max(line_size.y, font.get_height())
-		
+	var lines: PoolStringArray = text.split("\n")
+
+	size.y = lines.size() * font.get_height()
+	size.x = get_longest_line_width(lines, font)
+
 	return size
+
+
+func get_longest_line_width(lines: PoolStringArray, font: Font) -> float:
+	var larger_line_width: = 0.0
+	for line in lines:
+		var line_width: = font.get_string_size(line).x
+		larger_line_width = max(larger_line_width, line_width)
+		
+	return larger_line_width
 
 
 """
@@ -101,12 +122,11 @@ Returns an offset to compensate scrollbars
 """
 func get_padding(control: Control) -> Vector2:
 	var padding: = Vector2(0, 0)
-	
+
 	if control is RichTextLabel:
 		if control.scroll_active:
-			padding = Vector2(20, 0)
+			padding = Vector2(30, 0)
 	elif control is TextEdit:
-		padding = Vector2(20, 20)
-		
-	return padding
+		padding = Vector2(30, 30)
 
+	return padding

--- a/gdquest-godot-theme/addons/bounding_box_resize/plugin.cfg
+++ b/gdquest-godot-theme/addons/bounding_box_resize/plugin.cfg
@@ -3,5 +3,5 @@
 name="Bounding Box Resize"
 description="A plugin that automatically resize RichText and TextEdit's bounding box to fits its content."
 author="Henrique Campos"
-version="0.1.1"
+version="0.1.2"
 script="BoundingBoxResize.gd"


### PR DESCRIPTION
The PR aims to close #37 by checking which is larger, the current vertical size or the calculated one, and keep the largest size.

Also encapsulated the line width calculation into the `get_longest_line_width` method, among other minor refactoring, like `get_control_font` to encapsulate the font accessing procedures.