### PR TITLE
Improve input controller for AStar demo

### DIFF
--- a/02-15-astar-movement/default_env.tres
+++ b/02-15-astar-movement/default_env.tres
@@ -1,14 +1,12 @@
 [gd_resource type="Environment" load_steps=2 format=2]
 
 [sub_resource type="ProceduralSky" id=1]
-
 sky_top_color = Color( 0.647059, 0.839216, 0.945098, 1 )
 sky_horizon_color = Color( 0.839216, 0.917647, 0.980392, 1 )
 ground_bottom_color = Color( 0.156863, 0.184314, 0.211765, 1 )
 ground_horizon_color = Color( 0.423529, 0.396078, 0.372549, 1 )
 
 [resource]
-
 background_mode = 2
 background_sky = SubResource( 1 )
 

--- a/02-15-astar-movement/project.godot
+++ b/02-15-astar-movement/project.godot
@@ -51,7 +51,7 @@ window/stretch/aspect="keep"
 
 [editor_plugins]
 
-enabled=PoolStringArray( "rect_extents_gizmo" )
+enabled=PoolStringArray(  )
 
 [input]
 

--- a/02-15-astar-movement/src/Board/Board.gd
+++ b/02-15-astar-movement/src/Board/Board.gd
@@ -15,7 +15,8 @@ onready var size: Vector2 = path_finder.rect.size * path_finder.map.cell_size
 
 enum Feedback { INVALID = -1, ACTOR, OBJECT, FLAG, FORBID, ALLOW }
 
-var _has_feedback_flag = false
+var _feedback_flag_position: = Utils.V2_00
+var _has_feedback_flag: = false
 
 
 func _ready() -> void:
@@ -25,23 +26,23 @@ func _ready() -> void:
 
 
 func _unhandled_input(event: InputEvent) -> void:
-	if event is InputEventMouse and not _has_feedback_flag:
-		var at: Vector2 = path_finder.map.world_to_map(get_global_mouse_position())
+	var at: Vector2 = path_finder.map.world_to_map(get_global_mouse_position())
+	if event is InputEventMouse and not _feedback_flag_position == at:
 		var type: int = Feedback.FORBID if at in path_finder.map.obstacles else Feedback.ALLOW
 		_feedback_react(at, type)
 
 
 func _on_signal(msg: Dictionary = {}, which: String = "") -> void:
 	var type: int = Feedback.INVALID
-	var at: = Vector2()
+	var at: = Utils.V2_00
 
 	match msg:
 		{"is_leader": true, "destination": var destination}:
 			at = path_finder.map.world_to_map(destination)
-			type = Feedback.FLAG
 			continue
 		{"is_leader": true, ..}:
 			_has_feedback_flag = which == "started"
+			_feedback_flag_position = at
 			_feedback_react(at, type)
 
 
@@ -52,6 +53,8 @@ func _feedback_react(xy: Vector2, type: int) -> void:
 	feedback.clear()
 	if type != Feedback.INVALID:
 		feedback.set_cellv(xy, type)
+	if _has_feedback_flag:
+		feedback.set_cellv(_feedback_flag_position, Feedback.FLAG)
 
 
 """

--- a/02-15-astar-movement/src/Board/Encounter.gd
+++ b/02-15-astar-movement/src/Board/Encounter.gd
@@ -21,8 +21,8 @@ var _has_encountered_party: = false
 
 func _ready() -> void:
 	connect("input_event", self, "_on_Area_input_event")
-	connect("mouse_entered", Events, "emit_signal", ["encounter_probed", {encounter = self}])
-	connect("mouse_exited", Events, "emit_signal", ["encounter_probed", {encounter = null}])
+	connect("mouse_entered", Events, "emit_signal", ["encounter_probed", {encounter_probed = self}])
+	connect("mouse_exited", Events, "emit_signal", ["encounter_probed", {encounter_probed = null}])
 	Events.connect("party_member_walk_started", self, "_on_signal", ["started"])
 	Events.connect("party_member_walk_finished", self, "_on_signal", ["finished"])
 

--- a/02-15-astar-movement/src/Game.gd
+++ b/02-15-astar-movement/src/Game.gd
@@ -43,7 +43,7 @@ var draw_path: = [] setget set_draw_path
 func _ready() -> void:
 	Events.connect("encounter_probed", self, "_on_signal")
 	Events.connect("party_member_walk_finished", self, "_on_signal")
-	party.setup(board.size)
+	party.setup(board.size, board.path_finder.map.cell_size)
 
 
 func _draw() -> void:
@@ -52,10 +52,12 @@ func _draw() -> void:
 
 
 func _unhandled_input(event: InputEvent) -> void:
+	var leader: Actor = party.get_member(0)
 	var move_direction: = Utils.get_direction(event)
 	if event.is_action_pressed("tap"):
 		party_command({tap_position = board.get_global_mouse_position()})
-	elif move_direction != Vector2():
+	elif (Utils.any_action_just_pressed(["ui_left", "ui_up", "ui_right", "ui_down"])
+			and move_direction != Utils.V2_00 and not leader.is_walking):
 		party_command({move_direction = move_direction})
 
 
@@ -83,9 +85,9 @@ func party_command(msg: Dictionary = {}) -> void:
 	var path: = prepare_path(leader, msg)
 	var destination: = get_party_destination(leader, path)
 	var swapped: = try_swapping_party_members(leader, destination)
-	if not (swapped or leader.is_walking):
+	if not swapped and party.get_member_by_position(destination) == null:
 		members_walk(leader, path)
-	set_draw_path(path)
+		set_draw_path(path)
 
 
 """
@@ -100,7 +102,10 @@ func prepare_path(leader: Actor, msg: Dictionary = {}) -> Array:
 	var path: = []
 	match msg:
 		{"tap_position": var tap_position}:
+			tap_position = adjust_tap_position(leader.position, tap_position)
 			path = board.get_point_path(leader.position, tap_position)
+			if not path.empty():
+				path[0] = leader.position
 		{"move_direction": var move_direction}:
 			if move_direction in board.path_finder.possible_directions:
 				var from: Vector2 = leader.position
@@ -112,6 +117,30 @@ func prepare_path(leader: Actor, msg: Dictionary = {}) -> Array:
 
 
 """
+Adjusts `tap_position` if tap takes place on an encounter.
+
+Because encounters are treated as obstacles and thus the path finder can't find a path to an obstacle,
+`tap_position` is calculated to a valid cell position near the tapped encounter, closest to the leader position.
+This way, clicking on an encounter is valid and the party moves to a reasonable position so that it can interact
+with the respective encounter.
+
+Returns the Vector2 adjusted `tap_position` if tap takes place over an encounter.
+"""
+func adjust_tap_position(leader_position: Vector2, tap_position: Vector2) -> Vector2:
+	var n: = (leader_position - tap_position).normalized()
+	var min_angle: = INF
+	var selected_dir: = Utils.V2_00
+	if encounter_under_mouse != null:
+		for dir in Utils.CARDINAL_DIRECTIONS:
+			var angle: = abs(n.angle_to(dir))
+			if min_angle > angle:
+				min_angle = angle
+				selected_dir = dir
+		tap_position = encounter_under_mouse.position + board.path_finder.map.cell_size * selected_dir
+	return tap_position
+
+
+"""
 Moves the Party if possible. It first checks too ensure `destination` doesn't overlap with
 Party Members. If `destination` does overlap with a Party Member then the leader just swappes
 with the other Member.
@@ -119,7 +148,7 @@ with the other Member.
 Returns the extracted `destination` from `path`.
 """
 func get_party_destination(leader: Actor, path: Array) -> Vector2:
-	var destination: Vector2 = path[path.size() - 1] if not path.empty() else Vector2()
+	var destination: Vector2 = path[path.size() - 1] if not path.empty() else Utils.V2_00
 	return destination
 
 
@@ -131,11 +160,12 @@ It returns `true` if swap succeds, otherwise `false`.
 """
 func try_swapping_party_members(leader: Actor, destination: Vector2) -> bool:
 	var swapped = false
-	var other: Actor = party.get_member_by_position(destination)
-	if other != null and other != leader and party.get_member_count() != 1:
-		leader.walk([leader.position, other.position])
-		other.walk([other.position, leader.position])
-		swapped = true
+	if not leader.is_walking:
+		var other: Actor = party.get_member_by_position(destination)
+		if other != null and other != leader and party.get_member_count() != 1:
+			leader.walk([leader.position, other.position])
+			other.walk([other.position, leader.position])
+			swapped = true
 	return swapped
 
 
@@ -151,6 +181,7 @@ func members_walk(leader: Actor, path: Array) -> void:
 
 
 func set_draw_path(values: Array) -> void:
+	var leader: Actor = party.get_member(0)
 	draw_path = []
 	for point in values:
 		draw_path.push_back(point + DRAW_OFFSET)

--- a/02-15-astar-movement/src/Game.tscn
+++ b/02-15-astar-movement/src/Game.tscn
@@ -19,11 +19,9 @@
 [ext_resource path="res://assets/sprites/characters/robi.png" type="Texture" id=17]
 
 [sub_resource type="RectangleShape2D" id=1]
-
 extents = Vector2( 40, 40 )
 
 [sub_resource type="Animation" id=2]
-
 length = 0.001
 tracks/0/type = "value"
 tracks/0/path = NodePath("Interactive:position")
@@ -63,7 +61,6 @@ tracks/2/keys = {
 }
 
 [sub_resource type="Animation" id=3]
-
 length = 3.0
 loop = true
 tracks/0/type = "value"
@@ -104,7 +101,6 @@ tracks/2/keys = {
 }
 
 [sub_resource type="TileSet" id=4]
-
 0/name = "Actor"
 0/texture = ExtResource( 7 )
 0/tex_offset = Vector2( 0, 0 )

--- a/02-15-astar-movement/src/Party/Behaviors/Walk.tscn
+++ b/02-15-astar-movement/src/Party/Behaviors/Walk.tscn
@@ -15,3 +15,6 @@ autoplay = "<BASE>"
 anims/<BASE> = ExtResource( 2 )
 anims/walk = ExtResource( 3 )
 
+[node name="Timer" type="Timer" parent="."]
+one_shot = true
+

--- a/02-15-astar-movement/src/Party/Party.gd
+++ b/02-15-astar-movement/src/Party/Party.gd
@@ -14,7 +14,11 @@ the in other Systems like Dialog etc. (to be further explored).
 """
 
 
-func setup(board_size: Vector2) -> void:
+var _cell_size: = Utils.V2_00
+
+
+func setup(board_size: Vector2, cell_size: Vector2) -> void:
+	_cell_size = cell_size
 	for member in get_members():
 		member.setup(board_size)
 
@@ -39,7 +43,7 @@ func get_member(idx: int) -> Node:
 func get_member_by_position(p: Vector2) -> Node:
 	var member: Node = null
 	for m in get_members():
-		if (m.position - p).length() < Utils.ERR:
+		if (m.position - p).length() < (_cell_size/2).length():
 			member = m
 			break
 	return member

--- a/02-15-astar-movement/src/Utils.gd
+++ b/02-15-astar-movement/src/Utils.gd
@@ -4,7 +4,14 @@ General utility library that can be used across multiple projects as an autoload
 """
 
 
-const ERR : = 1e-6
+const ERR: = 1e-6
+const V2_00: = Vector2()
+const CARDINAL_DIRECTIONS: = [
+	Vector2(-1, 0),
+	Vector2(0, -1),
+	Vector2(1, 0),
+	Vector2(0, 1)
+]
 
 """
 Returns a normalized 4-way Vector2 (up, down, left, right) direction.
@@ -13,6 +20,18 @@ static func get_direction(event: InputEvent) -> Vector2:
 	return Vector2(
 			event.get_action_strength("ui_right") - event.get_action_strength("ui_left"),
 			event.get_action_strength("ui_down") - event.get_action_strength("ui_up"))
+
+
+"""
+Returns true if any of the `actions` is detected to be just pressed.
+"""
+static func any_action_just_pressed(actions: Array) -> bool:
+	var out: = false
+	for action in actions:
+		if Input.is_action_just_pressed(action):
+			out = true
+			break
+	return out
 
 
 """


### PR DESCRIPTION
- move party to cell even if party is moving already
- restrict keyboard movement so that animation doesn't have timing
issues since we start the animation at random positions on the timeline
- rely on speed instead of time for tween positions interpolation so
that the party members walk at same speed even on diagonals