### PR TITLE
Fix: Script variables was ignored on 'Intro Procedural Tilemap'

### DIFF
--- a/youtube-tutorial-demos/02-03-gdscript-intro-procedural-tilemap/end/GameWorld.gd
+++ b/youtube-tutorial-demos/02-03-gdscript-intro-procedural-tilemap/end/GameWorld.gd
@@ -13,7 +13,7 @@ export var perimeter_size := Vector2(1, 1)
 export(float, 0 , 1) var ground_probability := 0.1
 
 # Public variables
-var size := inner_size + 2 * perimeter_size
+onready var size := inner_size + 2 * perimeter_size
 
 # Private variables
 onready var _tile_map : TileMap = $TileMap

--- a/youtube-tutorial-demos/02-03-gdscript-intro-procedural-tilemap/exercise/GameWorld.gd
+++ b/youtube-tutorial-demos/02-03-gdscript-intro-procedural-tilemap/exercise/GameWorld.gd
@@ -15,7 +15,7 @@ export var inner_size : = Vector2(10, 8)
 export var perimeter_size : = Vector2(1, 1)
 export(float, 0 , 1) var obstacle_probability : = 0.1
 
-var size : = inner_size + 2 * perimeter_size
+onready var size : = inner_size + 2 * perimeter_size
 
 func _ready() -> void:
 	initialize()


### PR DESCRIPTION
We need to calculate the size at 'onready' to be able to use the value that is assigned in the editor.

If you change the 'inner_size' or 'perimeter_size' from the Script Variables on the Editor, it will no take effect because it calculate 'size' before of assign the value.